### PR TITLE
Add jsonInt64 type to massage inconsistently quoted data

### DIFF
--- a/pkg/pantheon/backup.go
+++ b/pkg/pantheon/backup.go
@@ -11,22 +11,23 @@ import (
 
 // Backup represents a single backup in the pantheon system.
 type Backup struct {
-	ID              string `json:"-"`
-	ArchiveType     string `json:"-"`
-	DownloadURL     string `json:"url,omitempty"`
-	SiteID          string `json:"-"`
-	EnvironmentName string `json:"-"`
-	BuildTag        string `json:"BUILD_TAG"`
-	BuildURL        string `json:"BUILD_URL"`
-	EndpointUUID    string `json:"endpoint_uuid"`
-	Folder          string `json:"folder"`
-	Size            int64  `json:"size"`
-	Timestamp       int64  `json:"timestamp"`
-	TotalDirs       int64  `json:"total_dirs"`
-	TotalEntries    int64  `json:"total_entries"`
-	TotalFiles      int64  `json:"total_files"`
-	TotalSize       int64  `json:"total_size"`
-	TTL             int64  `json:"ttl"`
+	ID              string    `json:"-"`
+	ArchiveType     string    `json:"-"`
+	DownloadURL     string    `json:"url,omitempty"`
+	SiteID          string    `json:"-"`
+	FileName        string    `json:"filename,omitempty"`
+	EnvironmentName string    `json:"-"`
+	BuildTag        string    `json:"BUILD_TAG"`
+	BuildURL        string    `json:"BUILD_URL"`
+	EndpointUUID    string    `json:"endpoint_uuid"`
+	Folder          string    `json:"folder"`
+	Size            jsonInt64 `json:"size"`
+	Timestamp       jsonInt64 `json:"timestamp"`
+	TotalDirs       jsonInt64 `json:"total_dirs"`
+	TotalEntries    jsonInt64 `json:"total_entries"`
+	TotalFiles      jsonInt64 `json:"total_files"`
+	TotalSize       jsonInt64 `json:"total_size"`
+	TTL             jsonInt64 `json:"ttl"`
 }
 
 // BackupList represents a list of all backups taken for a given site and environment combination.

--- a/pkg/pantheon/environment.go
+++ b/pkg/pantheon/environment.go
@@ -7,9 +7,9 @@ import (
 
 // Environment contains meta-data about a specific environment
 type Environment struct {
-	Name               string `json:"-"`
-	DNSZone            string `json:"dns_zone"`
-	EnvironmentCreated int64  `json:"environment_created"`
+	Name               string    `json:"-"`
+	DNSZone            string    `json:"dns_zone"`
+	EnvironmentCreated jsonInt64 `json:"environment_created"`
 	Lock               struct {
 		Locked   bool        `json:"locked"`
 		Password interface{} `json:"password"`

--- a/pkg/pantheon/jsonInt64.go
+++ b/pkg/pantheon/jsonInt64.go
@@ -13,25 +13,16 @@ type jsonInt64 int64
 
 func (f jsonInt64) MarshalJSON() ([]byte, error) {
 	return json.Marshal(int64(f))
-	// OR if you want "string" output, something like:
-	//return json.Marshal(strconv.FormatFloat(int64(f), 'g', -1, 64))
 }
 
 func (f *jsonInt64) UnmarshalJSON(data []byte) error {
 	var v int64
 
-	// Option C:
-	// Both the above might allow for weird things like only
-	// a leading quote or trailing quote or multiple
-	// leading/trailing quotes.
-	//
-	// To be more strict one could do something like this:
-
 	if len(data) >= 2 && data[0] == '"' && data[len(data)-1] == '"' {
 		// Remove single set of matching quotes
 		data = data[1 : len(data)-1]
 	}
-	// And, optionally if you also then want to remove any whitespace:
+	// And remove any whitespace:
 	data = bytes.TrimSpace(data)
 
 	err := json.Unmarshal(data, &v)

--- a/pkg/pantheon/jsonInt64.go
+++ b/pkg/pantheon/jsonInt64.go
@@ -1,0 +1,40 @@
+package pantheon
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// jsonFloat is an int64 which unmarshals from JSON
+// as either unquoted or quoted (with any amount
+// of internal leading/trailing whitespace).
+// it is based off of https://play.golang.org/p/KNPxDL1yqL
+type jsonInt64 int64
+
+func (f jsonInt64) MarshalJSON() ([]byte, error) {
+	return json.Marshal(int64(f))
+	// OR if you want "string" output, something like:
+	//return json.Marshal(strconv.FormatFloat(int64(f), 'g', -1, 64))
+}
+
+func (f *jsonInt64) UnmarshalJSON(data []byte) error {
+	var v int64
+
+	// Option C:
+	// Both the above might allow for weird things like only
+	// a leading quote or trailing quote or multiple
+	// leading/trailing quotes.
+	//
+	// To be more strict one could do something like this:
+
+	if len(data) >= 2 && data[0] == '"' && data[len(data)-1] == '"' {
+		// Remove single set of matching quotes
+		data = data[1 : len(data)-1]
+	}
+	// And, optionally if you also then want to remove any whitespace:
+	data = bytes.TrimSpace(data)
+
+	err := json.Unmarshal(data, &v)
+	*f = jsonInt64(v)
+	return err
+}

--- a/pkg/pantheon/jsonInt64_test.go
+++ b/pkg/pantheon/jsonInt64_test.go
@@ -1,0 +1,22 @@
+package pantheon
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestInt64Parsing ensures the jsonInt64 parsing is working as expected.
+func TestInt64Parsing(t *testing.T) {
+	assert := assert.New(t)
+	input := `[1, 20, "314", " 418   "]`
+	results := []int64{1, 20, 314, 418}
+	var nums []jsonInt64
+	err := json.Unmarshal([]byte(input), &nums)
+	assert.NoError(err)
+
+	for i, v := range results {
+		assert.Equal(int64(v), results[i])
+	}
+}

--- a/pkg/pantheon/site.go
+++ b/pkg/pantheon/site.go
@@ -17,10 +17,10 @@ type Site struct {
 		Attributes struct {
 			Label string `json:"label"`
 		} `json:"attributes"`
-		Created         int64  `json:"created"`
-		CreatedByUserID string `json:"created_by_user_id"`
-		Framework       string `json:"framework"`
-		Frozen          bool   `json:"frozen"`
+		Created         jsonInt64 `json:"created"`
+		CreatedByUserID string    `json:"created_by_user_id"`
+		Framework       string    `json:"framework"`
+		Frozen          bool      `json:"frozen"`
 		Holder          struct {
 			Email   string `json:"email"`
 			ID      string `json:"id"`
@@ -34,28 +34,28 @@ type Site struct {
 				Experiments                 struct{}    `json:"experiments"`
 				Firstname                   string      `json:"firstname"`
 				FullName                    string      `json:"full_name"`
-				GoogleAdwordsPushedCodeSent int64       `json:"google_adwords_pushed_code_sent"`
+				GoogleAdwordsPushedCodeSent jsonInt64   `json:"google_adwords_pushed_code_sent"`
 				GuiltyOfAbuse               interface{} `json:"guilty_of_abuse"`
 				InitialIdentityName         interface{} `json:"initial_identity_name"`
 				InitialIdentityStrategy     interface{} `json:"initial_identity_strategy"`
-				InvitesSent                 int64       `json:"invites_sent"`
-				InvitesToSite               int64       `json:"invites_to_site"`
-				InvitesToUser               int64       `json:"invites_to_user"`
+				InvitesSent                 jsonInt64   `json:"invites_sent"`
+				InvitesToSite               jsonInt64   `json:"invites_to_site"`
+				InvitesToUser               jsonInt64   `json:"invites_to_user"`
 				LastOrgSpinup               string      `json:"last-org-spinup"`
 				Lastname                    string      `json:"lastname"`
-				Maxdevsites                 int64       `json:"maxdevsites"`
+				Maxdevsites                 jsonInt64   `json:"maxdevsites"`
 				MinimizeJitDocs             bool        `json:"minimize_jit_docs"`
-				Modified                    int64       `json:"modified"`
+				Modified                    jsonInt64   `json:"modified"`
 				Organization                string      `json:"organization"`
 				Seens                       struct {
 					NewSiteSupportInterface bool `json:"new-site-support-interface"`
 				} `json:"seens"`
-				TrackingFirstCodePush       int64 `json:"tracking_first_code_push"`
-				TrackingFirstSiteCreate     int64 `json:"tracking_first_site_create"`
-				TrackingFirstTeamInvite     int64 `json:"tracking_first_team_invite"`
-				TrackingFirstWorkflowInLive int64 `json:"tracking_first_workflow_in_live"`
-				Verify                      int64 `json:"verify"`
-				WebServicesBusiness         bool  `json:"web_services_business"`
+				TrackingFirstCodePush       jsonInt64 `json:"tracking_first_code_push"`
+				TrackingFirstSiteCreate     jsonInt64 `json:"tracking_first_site_create"`
+				TrackingFirstTeamInvite     jsonInt64 `json:"tracking_first_team_invite"`
+				TrackingFirstWorkflowInLive jsonInt64 `json:"tracking_first_workflow_in_live"`
+				Verify                      jsonInt64 `json:"verify"`
+				WebServicesBusiness         bool      `json:"web_services_business"`
 			} `json:"profile"`
 		} `json:"holder"`
 		HolderID     string `json:"holder_id"`
@@ -65,11 +65,11 @@ type Site struct {
 			Timestamp string      `json:"timestamp"`
 			UserUUID  interface{} `json:"user_uuid"`
 		} `json:"last_code_push"`
-		LastFrozenAt  int64  `json:"last_frozen_at"`
-		Name          string `json:"name"`
-		Owner         string `json:"owner"`
-		PhpVersion    int64  `json:"php_version"`
-		PreferredZone string `json:"preferred_zone"`
+		LastFrozenAt  jsonInt64 `json:"last_frozen_at"`
+		Name          string    `json:"name"`
+		Owner         string    `json:"owner"`
+		PhpVersion    jsonInt64 `json:"php_version"`
+		PreferredZone string    `json:"preferred_zone"`
 		Product       struct {
 			ID       string `json:"id"`
 			Longname string `json:"longname"`
@@ -97,28 +97,28 @@ type Site struct {
 				Experiments                 struct{}    `json:"experiments"`
 				Firstname                   string      `json:"firstname"`
 				FullName                    string      `json:"full_name"`
-				GoogleAdwordsPushedCodeSent int64       `json:"google_adwords_pushed_code_sent"`
+				GoogleAdwordsPushedCodeSent jsonInt64   `json:"google_adwords_pushed_code_sent"`
 				GuiltyOfAbuse               interface{} `json:"guilty_of_abuse"`
 				InitialIdentityName         interface{} `json:"initial_identity_name"`
 				InitialIdentityStrategy     interface{} `json:"initial_identity_strategy"`
-				InvitesSent                 int64       `json:"invites_sent"`
-				InvitesToSite               int64       `json:"invites_to_site"`
-				InvitesToUser               int64       `json:"invites_to_user"`
+				InvitesSent                 jsonInt64   `json:"invites_sent"`
+				InvitesToSite               jsonInt64   `json:"invites_to_site"`
+				InvitesToUser               jsonInt64   `json:"invites_to_user"`
 				LastOrgSpinup               string      `json:"last-org-spinup"`
 				Lastname                    string      `json:"lastname"`
-				Maxdevsites                 int64       `json:"maxdevsites"`
+				Maxdevsites                 jsonInt64   `json:"maxdevsites"`
 				MinimizeJitDocs             bool        `json:"minimize_jit_docs"`
-				Modified                    int64       `json:"modified"`
+				Modified                    jsonInt64   `json:"modified"`
 				Organization                string      `json:"organization"`
 				Seens                       struct {
 					NewSiteSupportInterface bool `json:"new-site-support-interface"`
 				} `json:"seens"`
-				TrackingFirstCodePush       int64 `json:"tracking_first_code_push"`
-				TrackingFirstSiteCreate     int64 `json:"tracking_first_site_create"`
-				TrackingFirstTeamInvite     int64 `json:"tracking_first_team_invite"`
-				TrackingFirstWorkflowInLive int64 `json:"tracking_first_workflow_in_live"`
-				Verify                      int64 `json:"verify"`
-				WebServicesBusiness         bool  `json:"web_services_business"`
+				TrackingFirstCodePush       jsonInt64 `json:"tracking_first_code_push"`
+				TrackingFirstSiteCreate     jsonInt64 `json:"tracking_first_site_create"`
+				TrackingFirstTeamInvite     jsonInt64 `json:"tracking_first_team_invite"`
+				TrackingFirstWorkflowInLive jsonInt64 `json:"tracking_first_workflow_in_live"`
+				Verify                      jsonInt64 `json:"verify"`
+				WebServicesBusiness         bool      `json:"web_services_business"`
 			} `json:"profile"`
 		} `json:"user_in_charge"`
 		UserInChargeID string `json:"user_in_charge_id"`

--- a/pkg/pantheon/site_test.go
+++ b/pkg/pantheon/site_test.go
@@ -23,8 +23,8 @@ func TestSiteList(t *testing.T) {
 		w.Write(contents)
 	})
 
-	session.Request("GET", sl)
-
+	err := session.Request("GET", sl)
+	assert.NoError(err)
 	// Ensure we got a valid response and were able to unmarshal it as expected.
 	assert.Equal(len(sl.Sites), 2)
 	assert.Equal(sl.Sites[0].Site.Framework, "wordpress")

--- a/pkg/pantheon/testdata/sites.json
+++ b/pkg/pantheon/testdata/sites.json
@@ -272,7 +272,7 @@
       "created": 1430814231,
       "instrument": "8a8f2216-5d97-4901-9879-298ba9e7bf5e",
       "holder_type": "organization",
-      "php_version": 55,
+      "php_version": "55",
       "allow_cacheserver": true,
       "organization": "aaaa-bbbb-cccc-dddd",
       "last_code_push": {


### PR DESCRIPTION
## The Problem:
When working on drud/ddev#345 I noticed that sometimes integer data is inconsistently quoted by the Pantheon API. Since go is statically typed, it's not so great at dealing with that kind of inconsistency out of the box.

## The Fix:
Since we don't control the API or the JSON being sent to us, our best path forward is t be as fleixble as possible with what is sent. This introduces a new jsonInt64 data type which does some data massaging to ensure it can handle inconsistent quoting and whitespace.

## The Test:
This PR introduces a jsonInt64_test.go file which contains unit tests for the jsonInt64 type.
