### PR TITLE
Change User-Agent to Terminus/1.9 since they're turning off earlier, for drud/ddev#1731

### DIFF
--- a/pkg/pantheon/request.go
+++ b/pkg/pantheon/request.go
@@ -16,7 +16,7 @@ var APIHost = "https://terminus.pantheon.io:443/api"
 // Default HTTP header values
 const (
 	contentType = "application/json"
-	userAgent   = "Terminus/1.3.1-dev (php_version=7.1.5&script=bin/terminus)"
+	userAgent   = "Terminus/1.9 (php_version=7.1.5&script=bin/terminus)"
 )
 
 // RequestEntity provides an interface for making requests to the Pantheon API and marshaling/unmarshaling JSON data. Any object which


### PR DESCRIPTION
## The Problem:

drud/ddev#1731 explains that Pantheon is turning off access to older terminus clients.

## The Fix:

First attempt: Just report as terminus v1.9. 

We don't really have a way to know if that's adequate, but it's an attempt.

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

